### PR TITLE
Update XS2AiOSNetService with a more (unpublished) up-to-date version without Bitcode (see https://github.com/FinTecSystems/xs2a-ios-netservice/pull/2)

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,8 @@
     "start": "expo start --dev-client",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "expo-prebuild-clean-ios": "echo Y | npx expo prebuild --clean -p ios",
+    "expo-prebuild-clean-android": "echo Y | npx expo prebuild --clean -p android"
   },
   "dependencies": {
     "expo": "~49.0.15",

--- a/ios/IdNowAutoIdent.podspec
+++ b/ios/IdNowAutoIdent.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
     "Frameworks/FaceTecSDK.xcframework/**/*",
     "Frameworks/IDNowSDKCore.xcframework/**/*"
   ]
-  s.dependency 'XS2AiOS'
+  s.dependency 'XS2AiOSNetService'
   s.source_files = "**/*.{h,m,swift}"
 end

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module",
     "open:ios": "open -a \"Xcode\" example/ios",
-    "open:android": "open -a \"Android Studio\" example/android"
+    "open:android": "open -a \"Android Studio\" example/android",
+    "build-plugin": "tsc --build ./plugins/tsconfig.json"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Sorry, I went a bit too fast. I assumed since my app was archiving and going to TestFlight, the fix was good, but actually it was crashing at run time, not finding XS2AiOSNetService framework. The correct fix consist in targeting a more up to date version of XS2AiOSNetService rebuild with Xcode 15 to remove bitcode, but unfortunately not published in Cocoapods (which means we have to target the git branch HEAD, which cannot be done in podspec but only in podfile, which explains why this is as a plugin).

This time it is tested, I ran the plugin in my main project, archived, sent to TestFlight with no bitcode error, installed the TestFlight build and it finally worked like a charm. Cheers.

PS: Don't do the same mistake, don't forget to publish to npm both the expo-module and the plugin when you can. For now I rely on my branch, but I don't want to keep it this way forever.